### PR TITLE
Fix a "repmat Error"  for compatible issue

### DIFF
--- a/DPARSF/Subfunctions/y_RegressOutImgCovariates.m
+++ b/DPARSF/Subfunctions/y_RegressOutImgCovariates.m
@@ -149,7 +149,8 @@ VolumeAfterRemoveCov(isnan(VolumeAfterRemoveCov))=0;
 
 if isfield(CovariablesDef,'IsAddMeanBack') %YAN Chao-Gan, 20160415. Add the mean back.
     if CovariablesDef.IsAddMeanBack==1 || strcmpi(CovariablesDef.IsAddMeanBack, 'Yes')
-        VolumeAfterRemoveCov = VolumeAfterRemoveCov + repmat(MeanBrain,1,1,1,nDim4);
+%         VolumeAfterRemoveCov = VolumeAfterRemoveCov + repmat(MeanBrain,1,1,1,nDim4); % WangLei: Not compatible with matlab2012 
+        VolumeAfterRemoveCov = VolumeAfterRemoveCov + repmat(MeanBrain,[1,1,1,nDim4]);
     end
 end
 


### PR DESCRIPTION
When I using it to preprocess my Task data, DPABI showing me this error every time after nuisance covariates regression :"Error using repmat ,Too many input arguments...." .This PC has matlab2012 installed.
But strange thing is , in my macbook pro, with matlab2014b, it is always works fine.
So ,I found this issue and fixed it.
Hope this could help.
best
                        Wanglei