### PR TITLE
WIP: Dockerfile: extract ctf files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ RUN chmod +x /opt/DPABI/DPABI_StandAlone/DPABI_StandAlone
 RUN chmod +x /opt/DPABI/DPABI_StandAlone/run_DPABISurf_run_StandAlone.sh
 RUN chmod +x /opt/DPABI/DPABI_StandAlone/DPABISurf_run_StandAlone
 
+# Extract ctf for singularity support
+RUN /opt/DPABI/DPABI_StandAlone/run_DPABI_StandAlone.sh /opt/mcr/${MCR_VERSION} || true
+RUN /opt/DPABI/DPABI_StandAlone/run_DPABISurf_run_StandAlone.sh /opt/mcr/${MCR_VERSION} || true
+
 
 ENTRYPOINT []
 


### PR DESCRIPTION
Hi!

I'm trying to make this toolbox run on our Linux cluster using sinuglarity.

We can bootstrap a container super easy with

  docker build dpabi.sif docker://cgyan/dpabi:4.3_200401

However, a feature of singularity containers is the fact that they are read-only by design. The way precompiled matlab programs work is that matlab extracts the ctf archive once after the first call. This fails, because it can't write into the singularity filesystem. It would also result in (unwanted?) docker data.

By extracting the archives once upon container build the size increases a little (marginally when compared to the 8+GB of its total size), but supports singularity. This patch does just that.