### PR TITLE
Fixed a bug of "Can't read DPABIMessage from rfmri.org 

### DIFF
--- a/dpabi.m
+++ b/dpabi.m
@@ -79,11 +79,11 @@ if WebStatus
         uiwait(msgbox(sprintf('A new realease of DPABI is detected: %s, please update.',DPABILatestRelease)));
     end
     
-    DPABIMessage=urlread('http://rfmri.org/DPABIMessage.txt');
+    DPABIMessage=webread('http://rfmri.org/DPABIMessage.txt');
     if ~isempty(DPABIMessage)
         uiwait(msgbox(DPABIMessage,'DPABI Message'));
     end
-    DPABIMessageWeb=urlread('http://rfmri.org/DPABIMessageWeb.txt');
+    DPABIMessageWeb=webread('http://rfmri.org/DPABIMessageWeb.txt');
     if ~isempty(DPABIMessageWeb)
         web(DPABIMessageWeb,'-browser');
     end


### PR DESCRIPTION
Hi Prof. Yan,

This update resolved the problem that "Can't read DPABIMessage from rfmri.org and unable to open DPABI UI window" in some conditions. I have tested it on Matlab2021a macOS Sonoma 14.2.1.

Best,

Roger